### PR TITLE
fix get gcp projectID

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -17,11 +17,7 @@ const (
 	LevelCritical = "CRITICAL"
 )
 
-var projectID string
-
-func init() {
-	projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
-}
+var projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
 
 // Debugf is output of debug level log
 func Debugf(ctx context.Context, format string, a ...interface{}) {


### PR DESCRIPTION
projectID を init 出なくグローバルな変数で取得する。