### PR TITLE
add ci result icon in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/emahiro/ae-plain-logger.svg?branch=master)](https://travis-ci.org/emahiro/ae-plain-logger)
+
+
 # App Engine Plain Logger
 This is Plain Logger for App Engine 2nd Generation
 


### PR DESCRIPTION
This pull request purpose is to add travis ci result icon in README.md.