### PR TITLE
Write godoc of MwAEPlainLogger in detail.

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -11,27 +11,29 @@ import (
 
 var projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
 
-// Debugf is output of debug level log.
+// Debugf formats its arguments according to the format, analogous to fmt.Printf,
+// and records the text as log message at debug level.
+// The log message will be associated with the platform request linked with the context.
 func Debugf(ctx context.Context, format string, a ...interface{}) {
 	out(ctx, "DEBUG", format, a)
 }
 
-// Infof is output of information level log.
+// Infof is like Debugf, but the severity is info level.
 func Infof(ctx context.Context, format string, a ...interface{}) {
 	out(ctx, "INFO", format, a)
 }
 
-// Warningf is output of warning level log.
+// Warningf is like Debugf, but the severity is warning level.
 func Warningf(ctx context.Context, format string, a ...interface{}) {
 	out(ctx, "WARNING", format, a)
 }
 
-// Errorf is output of error level log.
+// Errorf is like Debugf, but the severity is error level.
 func Errorf(ctx context.Context, format string, a ...interface{}) {
 	out(ctx, "ERROR", format, a)
 }
 
-// Criticalf is output of critical level log.
+// Criticalf is like Debugf, but the severity is critical level.
 func Criticalf(ctx context.Context, format string, a ...interface{}) {
 	out(ctx, "CRITICAL", format, a)
 }

--- a/log/log.go
+++ b/log/log.go
@@ -11,27 +11,27 @@ import (
 
 var projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
 
-// Debugf is output of debug level log
+// Debugf is output of debug level log.
 func Debugf(ctx context.Context, format string, a ...interface{}) {
 	out(ctx, "DEBUG", format, a)
 }
 
-// Infof is output of information level log
+// Infof is output of information level log.
 func Infof(ctx context.Context, format string, a ...interface{}) {
 	out(ctx, "INFO", format, a)
 }
 
-// Warningf is output of warning level log
+// Warningf is output of warning level log.
 func Warningf(ctx context.Context, format string, a ...interface{}) {
 	out(ctx, "WARNING", format, a)
 }
 
-// Errorf is output of error level log
+// Errorf is output of error level log.
 func Errorf(ctx context.Context, format string, a ...interface{}) {
 	out(ctx, "ERROR", format, a)
 }
 
-// Criticalf is output of critical level log
+// Criticalf is output of critical level log.
 func Criticalf(ctx context.Context, format string, a ...interface{}) {
 	out(ctx, "CRITICAL", format, a)
 }

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -6,7 +6,9 @@ import (
 	"github.com/emahiro/ae-plain-logger/spancontext"
 )
 
-// MwAEPlainLogger is middleware for setting stackdrvier logging
+// MwAEPlainLogger is middleware for setting stackdrvier logging.
+// In this log middleware, label is required.
+// If you don't set label, this log middleware return panic.
 func MwAEPlainLogger(label string) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -8,7 +8,7 @@ import (
 
 // MwAEPlainLogger is middleware for setting stackdrvier logging.
 // In this log middleware, label is required.
-// If you don't set label, this log middleware return panic.
+// If you don't set label, this log middleware handle panic.
 func MwAEPlainLogger(label string) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/spancontext/spancontext.go
+++ b/spancontext/spancontext.go
@@ -8,13 +8,13 @@ import (
 	"go.opencensus.io/trace"
 )
 
-// AEPlainLogSpanContext is SpanContext struct of AppEnginePlainLogger
+// AEPlainLogSpanContext is SpanContext struct of AppEnginePlainLogger.
 type AEPlainLogSpanContext struct {
 	SpanID  string
 	TraceID string
 }
 
-// Get is method of get AEPlainLogSpanContext
+// Get is method of get AEPlainLogSpanContext.
 func Get(ctx context.Context) AEPlainLogSpanContext {
 	sc := trace.FromContext(ctx).SpanContext()
 	return AEPlainLogSpanContext{
@@ -23,7 +23,7 @@ func Get(ctx context.Context) AEPlainLogSpanContext {
 	}
 }
 
-// Set is method of set SpanContext in request
+// Set is method of set SpanContext in request.
 func Set(r *http.Request, label string) (context.Context, func()) {
 	ctx := r.Context()
 	span := new(trace.Span)

--- a/spancontext/spancontext.go
+++ b/spancontext/spancontext.go
@@ -14,7 +14,7 @@ type AEPlainLogSpanContext struct {
 	TraceID string
 }
 
-// Get is method of get AEPlainLogSpanContext.
+// Get is function of get AEPlainLogSpanContext.
 func Get(ctx context.Context) AEPlainLogSpanContext {
 	sc := trace.FromContext(ctx).SpanContext()
 	return AEPlainLogSpanContext{
@@ -23,7 +23,7 @@ func Get(ctx context.Context) AEPlainLogSpanContext {
 	}
 }
 
-// Set is method of set SpanContext in request.
+// Set is function of set SpanContext in request.
 func Set(r *http.Request, label string) (context.Context, func()) {
 	ctx := r.Context()
 	span := new(trace.Span)


### PR DESCRIPTION
`MwAEPlainLogger` のミドルウェアの godoc にpanicする場合があることをgodoc に追加で記載する。 