### PR TITLE
fix log format

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -15,41 +15,41 @@ var projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
 // and records the text as log message at debug level.
 // The log message will be associated with the platform request linked with the context.
 func Debugf(ctx context.Context, format string, a ...interface{}) {
-	out(ctx, "DEBUG", format, a)
+	out(ctx, "DEBUG", format, a...)
 }
 
 // Infof is like Debugf, but the severity is info level.
 func Infof(ctx context.Context, format string, a ...interface{}) {
-	out(ctx, "INFO", format, a)
+	out(ctx, "INFO", format, a...)
 }
 
 // Warningf is like Debugf, but the severity is warning level.
 func Warningf(ctx context.Context, format string, a ...interface{}) {
-	out(ctx, "WARNING", format, a)
+	out(ctx, "WARNING", format, a...)
 }
 
 // Errorf is like Debugf, but the severity is error level.
 func Errorf(ctx context.Context, format string, a ...interface{}) {
-	out(ctx, "ERROR", format, a)
+	out(ctx, "ERROR", format, a...)
 }
 
 // Criticalf is like Debugf, but the severity is critical level.
 func Criticalf(ctx context.Context, format string, a ...interface{}) {
-	out(ctx, "CRITICAL", format, a)
+	out(ctx, "CRITICAL", format, a...)
 }
 
 type jsonPayload struct {
 	Severity string `json:"severity"`
 	Message  string `json:"message"`
-	Trace    string `json:"logging.googleapis.com/trace,omitempty"`
-	SpanID   string `json:"logging.googleapis.com/spanId,omitempty"`
+	Trace    string `json:"logging.googleapis.com/trace"`
+	SpanID   string `json:"logging.googleapis.com/spanId"`
 }
 
 func out(ctx context.Context, severity, format string, a ...interface{}) {
 	sc := spancontext.Get(ctx)
 	payload := &jsonPayload{
 		Severity: severity,
-		Message:  fmt.Sprintf(format, a),
+		Message:  fmt.Sprintf(format, a...),
 		Trace:    fmt.Sprintf("projects/%s/traces/%s", projectID, sc.TraceID),
 		SpanID:   sc.SpanID,
 	}


### PR DESCRIPTION
format の引数の2つ目以降もformatで使えるように。
追加で効いてなかった omitempty を削除
