### PR TITLE
Support for Go1.16 & drop support for Go 1.14

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-versions: [1.14.x, 1.15.x]
+        go-versions: [1.15.x, 1.16.x]
         platform: [ubuntu-latest]
     name: Test
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
# What

This pull request purpose is below.

- Support for Go 1.16
- Drop support for Go1.14

---
- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
